### PR TITLE
Fixes indentation error in genetic_models

### DIFF
--- a/genmod/annotate_models/genetic_models.py
+++ b/genmod/annotate_models/genetic_models.py
@@ -66,6 +66,8 @@ import sys
 import logging
 from datetime import datetime
 
+from pprint import pprint as pp
+
 from .models import (check_dominant, check_recessive, check_compounds, 
 check_X_recessive, check_X_dominant)
 
@@ -440,6 +442,7 @@ def check_parents(model, individual_id, family, variant, variant_2={},
         if father_id != '0':
             father_genotype_2 = variant_2['genotypes'][father_id]
             parent_genotypes_2.append(father_genotype_2)
+        
         # One of the variants must come from father and one from mother
         if (len(parent_genotypes) == 2 and len(parent_genotypes_2) == 2):
             
@@ -460,10 +463,10 @@ def check_parents(model, individual_id, family, variant, variant_2={},
                     variant['inheritance_models'][family_id]['AR_comp'] = True
                     variant_2['inheritance_models'][family_id]['AR_comp'] = True
             
-            elif not strict:
-                variant['inheritance_models'][family_id]['AR_comp_dn'] = True
-                variant_2['inheritance_models'][family_id]['AR_comp_dn'] = True
-                variant['inheritance_models'][family_id]['AR_comp'] = True
-                variant_2['inheritance_models'][family_id]['AR_comp'] = True
+        elif not strict:
+            variant['inheritance_models'][family_id]['AR_comp_dn'] = True
+            variant_2['inheritance_models'][family_id]['AR_comp_dn'] = True
+            variant['inheritance_models'][family_id]['AR_comp'] = True
+            variant_2['inheritance_models'][family_id]['AR_comp'] = True
             
     return

--- a/tests/fixtures/comp_check.vcf
+++ b/tests/fixtures/comp_check.vcf
@@ -1,0 +1,17 @@
+##fileformat=VCFv4.1
+##INFO=<ID=MQ,Number=1,Type=Float,Description="RMS Mapping Quality">
+##INFO=<ID=Annotation,Number=.,Type=String,Description="Annotates what feature(s) this variant belongs to.">
+##contig=<ID=1,length=249250621,assembly=b37>
+##reference=file:///humgen/gsa-hpprojects/GATK/bundle/current/b37/human_g1k_v37.fasta
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	mother	proband
+1	879911	.	G	A	100	PASS	MQ=1;Annotation=SAMD11,NOC2L	GT:AD:GQ	0/0:10,10:60	0/1:10,10:60
+1	880012	.	A	G	100	PASS	MQ=1;Annotation=NOC2L	GT:AD:GQ	0/1:10,10:60	0/1:10,10:60
+1	880086	.	T	C	100	PASS	MQ=1;Annotation=NOC2L	GT:AD:GQ	0/1:10,10:60	0/1:10,10:60
+1	880199	.	G	A	100	PASS	MQ=1;Annotation=NOC2L	GT:AD:GQ	0/0:10,10:60	0/1:10,10:60
+1	880217	.	T	G	100	PASS	MQ=1;Annotation=NOC2L	GT:AD:GQ	0/0:10,10:60	0/1:10,10:60
+10	76154051	.	A	G	100	PASS	MQ=1;Annotation=ADK	GT:AD:GQ	0/1:10,10:60	0/1:10,10:60
+10	76154073	.	T	G	100	PASS	MQ=1;Annotation=ADK	GT:AD:GQ	0/0:10,10:60	0/1:10,10:60
+10	76154074	.	C	G	100	PASS	MQ=1;Annotation=ADK	GT:AD:GQ	0/1:10,10:60	0/1:10,10:60
+10	76154076	.	G	C	100	PASS	MQ=1;Annotation=ADK	GT:AD:GQ	0/0:10,10:60	0/1:10,10:60
+X	302253	.	CCCTCCTGCCCCT	C	100	PASS	MQ=1;Annotation=PPP2R3B	GT:AD:GQ	0/1:10,10:60	1/1:10,10:60
+MT	302253	.	CCCTCCTGCCCCT	C	100	PASS	MQ=1	GT:AD:GQ	0/1:10,10:60	1/1:10,10:60

--- a/tests/fixtures/duo.ped
+++ b/tests/fixtures/duo.ped
@@ -1,0 +1,3 @@
+#FamilyID	SampleID	Father	Mother	Sex	Phenotype
+1	proband	0	mother	1	2
+1	mother	0	0	2	1


### PR DESCRIPTION
There was a indentation error that made compounds disapear in the case of ony one parent.
Fix #82.
Adds some test files for this case.