### PR TITLE
Fix unstable variants in models output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Please add a new candidate release at the top after changing the latest one. Fee
 
 Try to use the following format:
 
+## [3.8.3]
+
+- Fixed unstable compounds order in models output ([#134](https://github.com/Clinical-Genomics/genmod/pull/134)))
+- Added `six` to requirements.txt and setup.py ([#134](https://github.com/Clinical-Genomics/genmod/pull/134)))
+
 ## [3.8.0]
 - Rank score normalisation
 

--- a/genmod/score_variants/compound_scorer.py
+++ b/genmod/score_variants/compound_scorer.py
@@ -267,6 +267,8 @@ class CompoundScorer(Process):
                             new_compound = "{0}>{1}".format(compound_id, compound_score)
                             scored_compound_list.append(new_compound)
 
+                        # Sort compound variants lexicographically
+                        scored_compound_list.sort()
                         new_compound_string = "{0}:{1}".format(
                             compound_family_id, '|'.join(scored_compound_list))
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ configobj == 5.0.8
 intervaltree == 3.1.0
 extract_vcf == 0.5
 vcftoolbox == 1.5.1
+six == 1.16.0

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ except (IOError, ImportError, RuntimeError):
     long_description = 'Tool for annotating patterns of genetic inheritance in Variant Call Format (VCF) files.'
 
 setup(name='genmod',
-    version='3.8.2',
+    version='3.8.3',
     description='Annotate genetic inheritance models in variant files',
     author = 'Mans Magnusson',
     author_email = 'mans.magnusson@scilifelab.se',
@@ -36,7 +36,8 @@ setup(name='genmod',
         'configobj >= 5.0.8',
         'intervaltree >= 3.1.0',
         'extract_vcf >= 0.5',
-        'vcftoolbox >= 1.5.1'
+        'vcftoolbox >= 1.5.1',
+        'six >= 1.16.0',
     ],
     packages=find_packages(
         exclude=('tests*', 'docs', 'examples', 'configs')


### PR DESCRIPTION
## Description

This PR sorts the `scored_compound_list` before writing, so that the output VCF always looks the same for a given input. 

### Added

-

### Changed

-

### Fixed

- #133.


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_[TOOL]-t [TOOL] -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
