### PR TITLE
~200x compounds speedup for VCFs with large variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Try to use the following format:
 ## [unreleased]
 ### Added
 - Pre-commit hooks with ruff for automatic check and format ([#200](https://github.com/Clinical-Genomics/genmod/pull/200))
+### Changed
+- Compounds `print_variant()` to use `cat` which provides significant speedups for large variants ([#189](https://github.com/Clinical-Genomics/genmod/pull/189))
 ### Fixed
 - Sorting command more inclusive for e.g. BusyBox sort for containers built with Bioconda ([#198](https://github.com/Clinical-Genomics/genmod/pull/198))
 - Fix symbolic SVs being silently dropped when sharing the same CHROM,POS and REF  ([#191](https://github.com/Clinical-Genomics/genmod/pull/191))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Try to use the following format:
 - Pre-commit hooks with ruff for automatic check and format ([#200](https://github.com/Clinical-Genomics/genmod/pull/200))
 ### Changed
 - Compounds `print_variant()` to use `cat` which provides significant speedups for large variants ([#189](https://github.com/Clinical-Genomics/genmod/pull/189))
+- Logging to use standard hierarchy instead of stderr ([#203](https://github.com/Clinical-Genomics/genmod/pull/203))
 ### Fixed
 - Sorting command more inclusive for e.g. BusyBox sort for containers built with Bioconda ([#198](https://github.com/Clinical-Genomics/genmod/pull/198))
 - Fix symbolic SVs being silently dropped when sharing the same CHROM,POS and REF  ([#191](https://github.com/Clinical-Genomics/genmod/pull/191))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Try to use the following format:
 ### Changed
 - Compounds `print_variant()` to use `cat` which provides significant speedups for large variants ([#189](https://github.com/Clinical-Genomics/genmod/pull/189))
 - Logging to use standard hierarchy instead of stderr ([#203](https://github.com/Clinical-Genomics/genmod/pull/203))
+- Multiprocessing `Manager` to `Queue` in score compounds ([#203](https://github.com/Clinical-Genomics/genmod/pull/203))
 ### Fixed
 - Sorting command more inclusive for e.g. BusyBox sort for containers built with Bioconda ([#198](https://github.com/Clinical-Genomics/genmod/pull/198))
 - Fix symbolic SVs being silently dropped when sharing the same CHROM,POS and REF  ([#191](https://github.com/Clinical-Genomics/genmod/pull/191))

--- a/genmod/commands/score_compounds.py
+++ b/genmod/commands/score_compounds.py
@@ -18,7 +18,7 @@ import subprocess
 import sys
 from codecs import open
 from datetime import datetime
-from multiprocessing import JoinableQueue, Queue, cpu_count, log_to_stderr, util
+from multiprocessing import JoinableQueue, Queue, cpu_count, util
 from tempfile import NamedTemporaryFile
 from time import sleep
 
@@ -31,8 +31,7 @@ from genmod.vcf_tools import HeaderParser, add_metadata, print_headers, sort_var
 
 from .utils import get_file_handle, outfile, processes, silent, temp_dir, variant_file
 
-logger = log_to_stderr(logging.INFO)
-logging.basicConfig(stream=sys.stderr, force=True)
+logger = logging.getLogger(__name__)
 util.abstract_sockets_supported = False
 
 

--- a/genmod/commands/score_compounds.py
+++ b/genmod/commands/score_compounds.py
@@ -147,7 +147,7 @@ def compound(
         temp_header_file.close()
 
         variant_printer = VariantPrinter(
-            task_queue=results, head=head, mode="normal", outfile=temp_variant_file.name
+            task_queue=results, head=head, mode="vcf", outfile=temp_variant_file.name
         )
 
         logger.info("Starting the variant printer process")
@@ -181,8 +181,8 @@ def compound(
         variant_printer.join()
         results.close()
 
-        with open(temp_header_file.name, "w", encoding="utf-8") as fh:
-            print_headers(head=head, outfile=fh, silent=silent)
+        with open(temp_header_file.name, "w", encoding="utf-8") as header_file:
+            print_headers(head=head, outfile=header_file, silent=silent)
 
         # Sort the variants temp file first
         sort_variants(infile=temp_variant_file.name, mode="vcf")

--- a/genmod/commands/score_compounds.py
+++ b/genmod/commands/score_compounds.py
@@ -14,10 +14,11 @@ from __future__ import print_function
 import itertools
 import logging
 import os
+import subprocess
 import sys
 from codecs import open
 from datetime import datetime
-from multiprocessing import JoinableQueue, Manager, cpu_count, log_to_stderr, util
+from multiprocessing import JoinableQueue, Queue, cpu_count, log_to_stderr, util
 from tempfile import NamedTemporaryFile
 from time import sleep
 
@@ -26,7 +27,7 @@ import click
 from genmod import __version__
 from genmod.score_variants import CompoundScorer
 from genmod.utils import VariantPrinter, get_batches
-from genmod.vcf_tools import HeaderParser, add_metadata, print_headers, print_variant, sort_variants
+from genmod.vcf_tools import HeaderParser, add_metadata, print_headers, sort_variants
 
 from .utils import get_file_handle, outfile, processes, silent, temp_dir, variant_file
 
@@ -105,7 +106,7 @@ def compound(
     logger.debug("Setting up a JoinableQueue for storing variant batches")
     variant_queue = JoinableQueue(maxsize=1000)
     logger.debug("Setting up a Queue for storing results from workers")
-    results = Manager().Queue()
+    results = Queue()
 
     num_scorers = processes
     # Adapt the number of processes to the machine that run the analysis
@@ -138,12 +139,15 @@ def compound(
         logger.debug("Build a tempfile for printing the variants")
         if temp_dir:
             temp_file = NamedTemporaryFile(delete=False, dir=temp_dir)
+            temp_header_file = NamedTemporaryFile(delete=False, dir=temp_dir)
         else:
             temp_file = NamedTemporaryFile(delete=False)
+            temp_header_file = NamedTemporaryFile(delete=False, dir=temp_dir)
         temp_file.close()
+        temp_header_file.close()
 
         variant_printer = VariantPrinter(
-            task_queue=results, head=head, mode="chromosome", outfile=temp_file.name
+            task_queue=results, head=head, mode="normal", outfile=temp_file.name
         )
 
         logger.info("Starting the variant printer process")
@@ -172,16 +176,23 @@ def compound(
                 logger.debug(f"Worker {worker} alive")
 
         variant_queue.join()
+
         results.put(None)
         variant_printer.join()
+        results.close()
 
-        sort_variants(infile=temp_file.name, mode="chromosome")
+        with open(temp_header_file.name, "w", encoding="utf-8") as fh:
+            print_headers(head=head, outfile=fh, silent=silent)
 
-        print_headers(head=head, outfile=outfile, silent=silent)
+        # Sort the variants temp file first
+        sort_variants(infile=temp_file.name, mode="vcf")
 
-        with open(temp_file.name, "r", encoding="utf-8") as f:
-            for line in f:
-                print_variant(variant_line=line, outfile=outfile, mode="modified", silent=silent)
+        # Combine header + sorted variants into final file
+        subprocess.run(
+            ["cat", temp_header_file.name, temp_file.name],
+            stdout=open(outfile.name, "wb"),
+            check=True,
+        )
     except Exception as e:
         logger.error(e)
         for worker in compound_scorers:
@@ -191,6 +202,7 @@ def compound(
     finally:
         logger.info("Removing temp file")
         os.remove(temp_file.name)
+        os.remove(temp_header_file.name)
         logger.debug("Temp file removed")
 
     logger.info("Time for whole analyis: {0}".format(str(datetime.now() - start_time_analysis)))

--- a/genmod/commands/score_compounds.py
+++ b/genmod/commands/score_compounds.py
@@ -142,7 +142,7 @@ def compound(
             temp_header_file = NamedTemporaryFile(delete=False, dir=temp_dir)
         else:
             temp_variant_file = NamedTemporaryFile(delete=False)
-            temp_header_file = NamedTemporaryFile(delete=False, dir=temp_dir)
+            temp_header_file = NamedTemporaryFile(delete=False)
         temp_variant_file.close()
         temp_header_file.close()
 

--- a/genmod/commands/score_compounds.py
+++ b/genmod/commands/score_compounds.py
@@ -138,16 +138,16 @@ def compound(
         # We use a temp file to store the processed variants
         logger.debug("Build a tempfile for printing the variants")
         if temp_dir:
-            temp_file = NamedTemporaryFile(delete=False, dir=temp_dir)
+            temp_variant_file = NamedTemporaryFile(delete=False, dir=temp_dir)
             temp_header_file = NamedTemporaryFile(delete=False, dir=temp_dir)
         else:
-            temp_file = NamedTemporaryFile(delete=False)
+            temp_variant_file = NamedTemporaryFile(delete=False)
             temp_header_file = NamedTemporaryFile(delete=False, dir=temp_dir)
-        temp_file.close()
+        temp_variant_file.close()
         temp_header_file.close()
 
         variant_printer = VariantPrinter(
-            task_queue=results, head=head, mode="normal", outfile=temp_file.name
+            task_queue=results, head=head, mode="normal", outfile=temp_variant_file.name
         )
 
         logger.info("Starting the variant printer process")
@@ -185,11 +185,11 @@ def compound(
             print_headers(head=head, outfile=fh, silent=silent)
 
         # Sort the variants temp file first
-        sort_variants(infile=temp_file.name, mode="vcf")
+        sort_variants(infile=temp_variant_file.name, mode="vcf")
 
         # Combine header + sorted variants into final file
         subprocess.run(
-            ["cat", temp_header_file.name, temp_file.name],
+            ["cat", temp_header_file.name, temp_variant_file.name],
             stdout=open(outfile.name, "wb"),
             check=True,
         )
@@ -200,9 +200,9 @@ def compound(
         variant_printer.terminate()
         context.abort()
     finally:
-        logger.info("Removing temp file")
-        os.remove(temp_file.name)
+        logger.info("Removing temp files")
+        os.remove(temp_variant_file.name)
         os.remove(temp_header_file.name)
-        logger.debug("Temp file removed")
+        logger.debug("Temp files removed")
 
     logger.info("Time for whole analyis: {0}".format(str(datetime.now() - start_time_analysis)))

--- a/genmod/score_variants/compound_scorer.py
+++ b/genmod/score_variants/compound_scorer.py
@@ -15,7 +15,7 @@ from __future__ import division, print_function
 
 import logging
 import traceback
-from multiprocessing import Process, log_to_stderr
+from multiprocessing import Process
 from typing import Dict, List, Tuple, Union
 
 from genmod.score_variants.cap_rank_score_to_min_bound import cap_rank_score_to_min_bound
@@ -27,7 +27,7 @@ from genmod.score_variants.score_variant import (
 )
 from genmod.vcf_tools import add_vcf_info, replace_vcf_info
 
-logger = log_to_stderr(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 
 def get_rank_score(

--- a/genmod/utils/variant_printer.py
+++ b/genmod/utils/variant_printer.py
@@ -12,15 +12,13 @@ Copyright (c) 2013 __MyCompanyName__. All rights reserved.
 from __future__ import print_function
 
 import logging
-import sys
 from codecs import open
-from multiprocessing import Process, log_to_stderr
+from multiprocessing import Process
 
 from genmod.utils import get_chromosome_priority, get_rank_score
 from genmod.vcf_tools import print_variant
 
-logger = log_to_stderr(logging.INFO)
-logging.basicConfig(stream=sys.stderr, force=True)
+logger = logging.getLogger(__name__)
 
 
 class VariantPrinter(Process):

--- a/genmod/vcf_tools/sort_variants.py
+++ b/genmod/vcf_tools/sort_variants.py
@@ -36,15 +36,9 @@ def sort_variants(infile, mode="chromosome"):
     command = [
         "sort",
     ]
-    if mode == "chromosome":
+    if mode == "chromosome" or mode == "vcf":
         command.append("-k1,1")
         command.append("-k3,3")
-        command.append("-s")
-        command.append("-V")  # Version sorting to deal with e.g. Un_* contigs
-
-    elif mode == "vcf":
-        command.append("-k1,1")
-        command.append("-k2,2")
         command.append("-s")
         command.append("-V")  # Version sorting to deal with e.g. Un_* contigs
 

--- a/genmod/vcf_tools/sort_variants.py
+++ b/genmod/vcf_tools/sort_variants.py
@@ -36,12 +36,16 @@ def sort_variants(infile, mode="chromosome"):
     command = [
         "sort",
     ]
-    if mode == "chromosome" or mode == "vcf":
+    if mode == "chromosome":
         command.append("-k1,1")
         command.append("-k3,3")
         command.append("-s")
         command.append("-V")  # Version sorting to deal with e.g. Un_* contigs
-
+    elif mode == "vcf":
+        command.append("-k1,1")
+        command.append("-k2,2")
+        command.append("-s")
+        command.append("-V")  # Version sorting to deal with e.g. Un_* contigs
     elif mode == "rank":
         command.append("-rn")
         command.append("-k1")

--- a/genmod/vcf_tools/sort_variants.py
+++ b/genmod/vcf_tools/sort_variants.py
@@ -26,7 +26,7 @@ def sort_variants(infile, mode="chromosome"):
 
     Args:
         infile : A string that is the path to a file
-        mode : 'chromosome' or 'rank'
+        mode : 'chromosome', 'vcf' or 'rank'
         outfile : The path to an outfile where the variants should be printed
 
     Returns:
@@ -40,7 +40,10 @@ def sort_variants(infile, mode="chromosome"):
         command.append("-k1,1V")  # Version sorting to deal with e.g. Un_* contigs
         command.append("-k3,3n")  # Sorting positions numerically
         command.append("-s")
-
+    elif mode == "vcf":
+        command.append("-k1,1V")  # Version sorting to deal with e.g. Un_* contigs
+        command.append("-k2,2n")  # Sorting positions numerically
+        command.append("-s")
     elif mode == "rank":
         command.append("-rn")
         command.append("-k1")

--- a/tests/functionality/test_score_variants_ranks_score_is_float.py
+++ b/tests/functionality/test_score_variants_ranks_score_is_float.py
@@ -95,5 +95,7 @@ def test_rankscore_is_float_type():
     )
     assert result.exit_code == 0
     # THEN expect all rank scores (including modified compound scores) to be float type
-    for rank_score_string in _generate_rank_score_strings_from_file(file_path=compound_output_file.name):
+    for rank_score_string in _generate_rank_score_strings_from_file(
+        file_path=compound_output_file.name
+    ):
         _check_rankscore_string_is_float(rank_score_string)

--- a/tests/functionality/test_score_variants_ranks_score_is_float.py
+++ b/tests/functionality/test_score_variants_ranks_score_is_float.py
@@ -82,17 +82,18 @@ def test_rankscore_is_float_type():
 
     # GIVEN some ranked VCF file, run compound scoring (which modify the RankScore)
     runner = CliRunner()
+    compound_output_file = NamedTemporaryFile(suffix=".vcf", delete=False)
+    compound_output_file.close()
     # WHEN computing compound score
     result = runner.invoke(
         score_compounds_command,
         [
             temporary_file.name,
+            "-o",
+            compound_output_file.name,
         ],
     )
     assert result.exit_code == 0
-    temporary_file = NamedTemporaryFile()
-    with open(temporary_file.name, "w") as file:
-        file.write(result.stdout_bytes.decode("utf-8"))  # Save processed VCF to file
     # THEN expect all rank scores (including modified compound scores) to be float type
-    for rank_score_string in _generate_rank_score_strings_from_file(file_path=temporary_file.name):
+    for rank_score_string in _generate_rank_score_strings_from_file(file_path=compound_output_file.name):
         _check_rankscore_string_is_float(rank_score_string)


### PR DESCRIPTION
## Description

The scoring and sorting of a Nallo clinical SV VCF takes ~5 seconds. Thereafter, ~15 minutes is spent on printing the variants to the output file. This PR replaces `print_variant()` with `cat` to make that process take two seconds.

Additionally, I ran into some Multiprocessing errors. Replacing Manager with Queue and then closing results seems to do the trick (LLM suggestion). Turning off logging to stderr by default to reduce noice in e.g. pytest.

### Changed

- Compounds `print_variant()` to use `cat` which provides significant speedups for large variants 
- Logging to use standard hierarchy instead of stderr
- Multiprocessing `Manager` to `Queue` in score compounds 



### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_[TOOL]-t [TOOL] -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
