### PR TITLE
Fix certain SVs silently dropped when sharing chrom, pos, ref, alt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Please add a new candidate release at the top after changing the latest one. Fee
 Try to use the following format:
 
 ## [3.10.3]
-- Fix symbolic SVs being silently dropped when sharing the same CHROM,POS and REF  ([]())
+- Fix symbolic SVs being silently dropped when sharing the same CHROM,POS and REF  ([#191](https://github.com/Clinical-Genomics/genmod/pull/191))
 
 ## [3.10.2]
 ### Fixed 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Please add a new candidate release at the top after changing the latest one. Fee
 
 Try to use the following format:
 
+## [3.10.3]
+- Fix symbolic SVs being silently dropped when sharing the same CHROM,POS and REF  ([]())
+
 ## [3.10.2]
 ### Fixed 
 - Add scoring normalisation for flag lookup mode ([#177](https://github.com/Clinical-Genomics/genmod/pull/177))

--- a/genmod/utils/get_batches.py
+++ b/genmod/utils/get_batches.py
@@ -63,9 +63,9 @@ def get_batches(
     for line in variants:
         if not line.startswith("#"):
             variant = get_variant_dict(line, header_line)
+            variant["info_dict"] = get_info_dict(variant["INFO"])
             variant_id = get_variant_id(variant)
             variant["variant_id"] = variant_id
-            variant["info_dict"] = get_info_dict(variant["INFO"])
 
             if vep:
                 variant["vep_info"] = get_vep_dict(

--- a/genmod/vcf_tools/parse_variant.py
+++ b/genmod/vcf_tools/parse_variant.py
@@ -47,9 +47,10 @@ def get_info_dict(info_line):
 def get_variant_id(variant_dict):
     """Build a variant id
 
-    The variant id is a string made of CHROM_POS_REF_ALT
-
-    The alt field for svs needs some massage to work downstream.
+    Build CHROM_POS_REF_ALT and sanitize ALT by stripping '<>[]:'.
+    For structural variants with symbolic ALT values (for example <DEL>),
+    append _END{END} when END is available. If END is missing but SVLEN is
+    present, append _SVLEN{SVLEN} instead.
 
     Args:
         variant_dict (dict): A variant dictionary

--- a/genmod/vcf_tools/parse_variant.py
+++ b/genmod/vcf_tools/parse_variant.py
@@ -60,11 +60,24 @@ def get_variant_id(variant_dict):
     chrom = variant_dict["CHROM"]
     pos = variant_dict["POS"]
     ref = variant_dict["REF"]
+    alt_raw = variant_dict["ALT"]
     # There are several symbols in structural variant calls that make
     # things hard. We will strip those symbols
     bad_chars = "<>[]:"
-    alt = "".join(c for c in variant_dict["ALT"] if c not in bad_chars)
-    return "_".join([chrom, pos, ref, alt])
+    alt = "".join(c for c in alt_raw if c not in bad_chars)
+    base_id = "_".join([chrom, pos, ref, alt])
+
+    # For SVs with symbolic ALT values, we append END/SVLEN if present to reduce id collisions
+    if "<" in alt_raw or ">" in alt_raw:
+        info = variant_dict.get("info_dict", {})
+        end = info.get("END")
+        svlen = info.get("SVLEN")
+        if end:
+            return "{}_END{}".format(base_id, end)
+        if svlen:
+            return "{}_SVLEN{}".format(base_id, svlen)
+
+    return base_id
 
 
 def get_vep_dict(vep_string, vep_header, allele=None):

--- a/tests/fixtures/test_vcf_sv_same_pos.vcf
+++ b/tests/fixtures/test_vcf_sv_same_pos.vcf
@@ -1,0 +1,15 @@
+##fileformat=VCFv4.1
+##FILTER=<ID=PASS,Description="All filters passed">
+##FORMAT=<ID=CN,Number=1,Type=Float,Description="Copy number">
+##FORMAT=<ID=CNQ,Number=1,Type=Float,Description="Copy number genotype quality">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##INFO=<ID=END,Number=1,Type=Integer,Description="End position of the variant described in this record">
+##INFO=<ID=SVLEN,Number=A,Type=Integer,Description="Length of structural variant">
+##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
+##INFO=<ID=Annotation,Number=.,Type=String,Description="Annotates what feature(s) this variant belongs to.">
+##contig=<ID=chr16,length=90338345>
+##ALT=<ID=DEL,Description="Deletion">
+##source=MergeVCF
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	proband	father	mother
+chr16	1	.	G	<DEL>	487	PASS	SVTYPE=DEL;END=1001;SVLEN=1000	GT:CN:CNQ	0/1:1:487	./.:.:.	./.:.:.
+chr16	1	.	G	<DEL>	69	PASS	SVTYPE=DEL;END=101;SVLEN=100	GT:CN:CNQ	./.:.:.	./.:.:.	0/1:1:69

--- a/tests/fixtures/test_vcf_sv_same_pos_annotated.vcf
+++ b/tests/fixtures/test_vcf_sv_same_pos_annotated.vcf
@@ -1,0 +1,22 @@
+##fileformat=VCFv4.1
+##FILTER=<ID=PASS,Description="All filters passed">
+##FORMAT=<ID=CN,Number=1,Type=Float,Description="Copy number">
+##FORMAT=<ID=CNQ,Number=1,Type=Float,Description="Copy number genotype quality">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##INFO=<ID=END,Number=1,Type=Integer,Description="End position of the variant described in this record">
+##INFO=<ID=SVLEN,Number=A,Type=Integer,Description="Length of structural variant">
+##INFO=<ID=GeneticModels,Number=.,Type=String,Description="':'-separated list of genetic models for this variant.">
+##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
+##INFO=<ID=GeneticModels,Number=.,Type=String,Description="':'-separated list of genetic models for this variant.">
+##INFO=<ID=ModelScore,Number=1,Type=Integer,Description="PHRED score for genotype models.">
+##INFO=<ID=Compounds,Number=.,Type=String,Description="List of compound pairs for this variant.The list is splitted on ',' family id is separated with compoundswith ':'. Compounds are separated with '|'.">
+##INFO=<ID=Annotation,Number=.,Type=String,Description="Annotates what feature(s) this variant belongs to.">
+##INFO=<ID=CADD,Number=A,Type=Float,Description="The CADD relative score for this alternative.">
+##INFO=<ID=1000GAF,Number=A,Type=Float,Description="Frequency in the 1000G database.">
+##INFO=<ID=CLNSIG,Number=A,Type=String,Description="Variant Clinical Significance, 0 - Uncertain significance, 1 - not provided, 2 - Benign, 3 - Likely benign, 4 - Likely pathogenic, 5 - Pathogenic, 6 - drug response, 7 - histocompatibility, 255 - other">
+##ALT=<ID=DEL,Description="Deletion">
+##contig=<ID=chr16,length=90338345>
+##source=MergeVCF
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	proband	father	mother
+chr16	1	.	G	<DEL>	487	PASS	SVTYPE=DEL;END=1001;SVLEN=1000;GeneticModels=1:AD|AD_dn	GT:CN:CNQ	0/1:1:487	./.:.:.	./.:.:.
+chr16	1	.	G	<DEL>	69	PASS	SVTYPE=DEL;END=101;SVLEN=100;GeneticModels=1:AR_hom|AR_hom_dn	GT:CN:CNQ	./.:.:.	./.:.:.	0/1:1:69

--- a/tests/functionality/test_annotate_models.py
+++ b/tests/functionality/test_annotate_models.py
@@ -12,6 +12,7 @@ VCF_FILE_WITH_CHR = "tests/fixtures/test_vcf_regions_with_chr.vcf"
 FAMILY_FILE = "tests/fixtures/recessive_trio.ped"
 BAD_FAMILY_FILE = "tests/fixtures/annotate_models/one_ind.ped"
 EMPTY_VCF_FILE = "tests/fixtures/empty.vcf"
+SV_SAME_POS_VCF_FILE = "tests/fixtures/test_vcf_sv_same_pos.vcf"
 
 init_log(logger, loglevel="INFO")
 
@@ -95,3 +96,20 @@ def test_annotate_models_chr_prefix():
     # Assert that the lists of models are identical
     assert len(models_list) > 0 and len(models_list_with_chr) > 0, "No models in VCFs"
     assert models_list == models_list_with_chr, "Models differ between VCF files."
+
+
+def test_annotate_models_same_pos_sv_keeps_distinct_end_variants():
+    """Test that same-position symbolic SV records are not collapsed."""
+    runner = CliRunner()
+    # Use SVTYPE as annotation keyword so both DEL records are processed in the same batch.
+    result = runner.invoke(models_command, [SV_SAME_POS_VCF_FILE, "-f", FAMILY_FILE, "-k", "SVTYPE"])
+
+    assert result.exit_code == 0
+
+    with NamedTemporaryFile(delete=False) as temp_file:
+        temp_file.write(result.stdout_bytes)
+        temp_file.seek(0)
+        output_variants = list(generate_variants_from_file(temp_file.name))
+
+    assert len(output_variants) == 2
+    assert {variant["info_dict"].get("END") for variant in output_variants} == {"1001", "101"}

--- a/tests/functionality/test_annotate_models.py
+++ b/tests/functionality/test_annotate_models.py
@@ -102,7 +102,9 @@ def test_annotate_models_same_pos_sv_keeps_distinct_end_variants():
     """Test that same-position symbolic SV records are not collapsed."""
     runner = CliRunner()
     # Use SVTYPE as annotation keyword so both DEL records are processed in the same batch.
-    result = runner.invoke(models_command, [SV_SAME_POS_VCF_FILE, "-f", FAMILY_FILE, "-k", "SVTYPE"])
+    result = runner.invoke(
+        models_command, [SV_SAME_POS_VCF_FILE, "-f", FAMILY_FILE, "-k", "SVTYPE"]
+    )
 
     assert result.exit_code == 0
 

--- a/tests/functionality/test_score_variants.py
+++ b/tests/functionality/test_score_variants.py
@@ -1,7 +1,10 @@
+from tempfile import NamedTemporaryFile
+
 from click.testing import CliRunner
 from genmod import logger
 from genmod.commands import score_command
 from genmod.log import init_log
+from test_utils import generate_variants_from_file
 
 ANNOTATED_VCF_FILE = "tests/fixtures/test_vcf_annotated.vcf"
 VCF_FILE = "tests/fixtures/test_vcf_regions.vcf"
@@ -9,6 +12,7 @@ EMPTY_VCF_FILE = "tests/fixtures/test_vcf_annotated_empty.vcf"
 SCORED_VCF = "tests/fixtures/test_vcf_annotated_scored.vcf"
 SCORE_CONFIG = "tests/fixtures/score_variants/genmod_example.ini"
 BAD_FAMILY_FILE = "tests/fixtures/annotate_models/one_ind.ped"
+SV_SAME_POS_VCF_FILE = "tests/fixtures/test_vcf_sv_same_pos_annotated.vcf"
 
 init_log(logger, loglevel="INFO")
 
@@ -46,6 +50,23 @@ def test_annotate_models_already_scored():
     result = runner.invoke(score_command, [SCORED_VCF, "-c", SCORE_CONFIG])
 
     assert result.exit_code == 1
+
+
+def test_genmod_score_same_pos_sv_keeps_distinct_end_variants():
+    """Test scoring keeps symbolic SVs at same locus as distinct variants."""
+    runner = CliRunner()
+    result = runner.invoke(score_command, [SV_SAME_POS_VCF_FILE, "-c", SCORE_CONFIG])
+
+    assert result.exit_code == 0
+
+    with NamedTemporaryFile(delete=False) as temp_file:
+        temp_file.write(result.stdout_bytes)
+        temp_file.seek(0)
+        output_variants = list(generate_variants_from_file(temp_file.name))
+
+    assert len(output_variants) == 2
+    assert {variant["info_dict"].get("END") for variant in output_variants} == {"1001", "101"}
+    assert all("RankScore" in variant["info_dict"] for variant in output_variants)
 
 
 #

--- a/tests/vcf_tools/test_parse_variant.py
+++ b/tests/vcf_tools/test_parse_variant.py
@@ -10,6 +10,36 @@ class TestGetVariantId:
         variant = {"CHROM": "1", "POS": "10", "REF": "N", "ALT": "<INS>"}
         assert get_variant_id(variant) == "1_10_N_INS"
 
+    def test_get_variant_id_sv_end(self):
+        variant = {
+            "CHROM": "1",
+            "POS": "10",
+            "REF": "N",
+            "ALT": "<DEL>",
+            "info_dict": {"END": "20"},
+        }
+        assert get_variant_id(variant) == "1_10_N_DEL_END20"
+
+    def test_get_variant_id_sv_svlen(self):
+        variant = {
+            "CHROM": "1",
+            "POS": "10",
+            "REF": "N",
+            "ALT": "<DEL>",
+            "info_dict": {"SVLEN": "-10"},
+        }
+        assert get_variant_id(variant) == "1_10_N_DEL_SVLEN-10"
+
+    def test_get_variant_id_sv_end_over_svlen(self):
+        variant = {
+            "CHROM": "1",
+            "POS": "10",
+            "REF": "N",
+            "ALT": "<DEL>",
+            "info_dict": {"END": "20", "SVLEN": "-10"},
+        }
+        assert get_variant_id(variant) == "1_10_N_DEL_END20"
+
     def test_get_variant_id_sv_dup_tandem(self):
         variant = {"CHROM": "1", "POS": "10", "REF": "N", "ALT": "<DUP:TANDEM>"}
         assert get_variant_id(variant) == "1_10_N_DUPTANDEM"


### PR DESCRIPTION
## Description

### Added 
- Tests for the specific changes

### Changed

- `variant_id` in `get_batches` is extended with SVLEN or END for SVs with symbolic ALT values

### Fixed

- fixes #190 


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_[TOOL]-t [TOOL] -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
