### PR TITLE
Print header in `genmod models` when running with `--processes 1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,12 @@ Please add a new candidate release at the top after changing the latest one. Fee
 
 Try to use the following format:
 
+## [unreleased]
+### Fixed
+- Print header in `genmod models` when running with `--processes 1` ([#199](https://github.com/Clinical-Genomics/genmod/pull/199))
+
 ## [3.10.2]
-### Fixed 
+### Fixed
 - Add scoring normalisation for flag lookup mode ([#177](https://github.com/Clinical-Genomics/genmod/pull/177))
 - Fix crash on test for missing annotation key for phased mode ([#178](https://github.com/Clinical-Genomics/genmod/pull/178))
 - Bugfixes related to multiprocessing stability and error handling ([#183](https://github.com/Clinical-Genomics/genmod/pull/183) and [#186](https://github.com/Clinical-Genomics/genmod/pull/186))
@@ -33,7 +37,7 @@ Try to use the following format:
 - Fixed sorting of variants ([#152](https://github.com/Clinical-Genomics/genmod/pull/152))
 - genmod annotate for mitochondrial variants when using the `chrM` notation ([#157](https://github.com/Clinical-Genomics/genmod/pull/157))
 - Fix linting issues ([#154](https://github.com/Clinical-Genomics/genmod/issues/154))
-- genmod models adds headers to VCF even if it contains no variants ([#160](https://github.com/Clinical-Genomics/genmod/pull/160)) 
+- genmod models adds headers to VCF even if it contains no variants ([#160](https://github.com/Clinical-Genomics/genmod/pull/160))
 
 ## [3.9]
 - Fixed wrong models when chromosome X was named `chrX` and not `X` ([#135](https://github.com/Clinical-Genomics/genmod/pull/135))

--- a/genmod/utils/variant_printer.py
+++ b/genmod/utils/variant_printer.py
@@ -64,7 +64,7 @@ class VariantPrinter(Process):
 
         if self.outfile:
             if isinstance(self.outfile, str):
-                self.outfile = open(self.outfile, "w+", encoding="utf-8")
+                self.outfile = open(self.outfile, "a", encoding="utf-8")
 
         while True:
             # A task is a variant dictionary

--- a/tests/functionality/test_annotate_models.py
+++ b/tests/functionality/test_annotate_models.py
@@ -95,3 +95,19 @@ def test_annotate_models_chr_prefix():
     # Assert that the lists of models are identical
     assert len(models_list) > 0 and len(models_list_with_chr) > 0, "No models in VCFs"
     assert models_list == models_list_with_chr, "Models differ between VCF files."
+
+
+def test_annotate_models_outfile_header():
+    """Test that headers are present in outfile with --processes 1 and 2"""
+    for procs in ["1", "2"]:
+        runner = CliRunner()
+        with NamedTemporaryFile(delete=False) as temp_file:
+            result = runner.invoke(
+                models_command,
+                [VCF_FILE, "-f", FAMILY_FILE, "--processes", procs, "--outfile", temp_file.name],
+            )
+            assert result.exit_code == 0
+            temp_file.seek(0)
+            output = temp_file.read().decode("utf-8")
+            assert "##fileformat=" in output
+            assert "##INFO=<ID=GeneticModels" in output

--- a/tests/functionality/test_annotate_models.py
+++ b/tests/functionality/test_annotate_models.py
@@ -112,8 +112,8 @@ def test_annotate_models_outfile_header():
             output = temp_file.read().decode("utf-8")
             assert "##fileformat=" in output
             assert "##INFO=<ID=GeneticModels" in output
-            
-            
+
+
 def test_annotate_models_same_pos_sv_keeps_distinct_end_variants():
     """Test that same-position symbolic SV records are not collapsed."""
     runner = CliRunner()


### PR DESCRIPTION
## Description

Closes #188. Genmod was not printing the VCF header then running `genmod models` with `--processes 1`, because when not using multiprocessing the header was written directly to the output file, and then the VariantPrinter was not in append mode. With multiprocessing the variants are first written to a temporary file, so this problem was not observed there.

### Fixed

- Print header in `genmod models` when running with `--processes 1`


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_[TOOL]-t [TOOL] -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
