### PR TITLE
Fixed duplicate parameter `-s` in genmod models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,12 @@ Please add a new candidate release at the top after changing the latest one. Fee
 
 Try to use the following format:
 
+## [unreleased]
+### Fixed
+- Fixed duplicate parameter `-s` in genmod models
+
 ## [3.10.2]
-### Fixed 
+### Fixed
 - Add scoring normalisation for flag lookup mode ([#177](https://github.com/Clinical-Genomics/genmod/pull/177))
 - Fix crash on test for missing annotation key for phased mode ([#178](https://github.com/Clinical-Genomics/genmod/pull/178))
 - Bugfixes related to multiprocessing stability and error handling ([#183](https://github.com/Clinical-Genomics/genmod/pull/183) and [#186](https://github.com/Clinical-Genomics/genmod/pull/186))
@@ -33,7 +37,7 @@ Try to use the following format:
 - Fixed sorting of variants ([#152](https://github.com/Clinical-Genomics/genmod/pull/152))
 - genmod annotate for mitochondrial variants when using the `chrM` notation ([#157](https://github.com/Clinical-Genomics/genmod/pull/157))
 - Fix linting issues ([#154](https://github.com/Clinical-Genomics/genmod/issues/154))
-- genmod models adds headers to VCF even if it contains no variants ([#160](https://github.com/Clinical-Genomics/genmod/pull/160)) 
+- genmod models adds headers to VCF even if it contains no variants ([#160](https://github.com/Clinical-Genomics/genmod/pull/160))
 
 ## [3.9]
 - Fixed wrong models when chromosome X was named `chrX` and not `X` ([#135](https://github.com/Clinical-Genomics/genmod/pull/135))

--- a/genmod/commands/annotate_models.py
+++ b/genmod/commands/annotate_models.py
@@ -64,7 +64,6 @@ util.abstract_sockets_supported = False
 )
 @click.option("--phased", is_flag=True, help="If data is phased use this flag.")
 @click.option(
-    "-s",
     "--strict",
     is_flag=True,
     help="If strict model annotations should be used(see documentation).",
@@ -78,7 +77,7 @@ util.abstract_sockets_supported = False
     "-k",
     "--keyword",
     default="Annotation",
-    help="""What annotation keyword that should be used when 
+    help="""What annotation keyword that should be used when
                     searching for features.""",
 )
 @outfile


### PR DESCRIPTION
## Description

We already have a `-s,--silent` parameter in genmod. 

### Added

-

### Changed

-

### Fixed

- Duplicate parameter `-s` in genmod models


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_[TOOL]-t [TOOL] -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
