### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,31 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+Thank you for taking the time to contribute an issue!
+
+**⚠️ Important:** Please avoid sharing any sensitive or personal information, including text or images, in this issue.
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,22 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**⚠️ Important:** Please avoid sharing any sensitive or personal information, including text or images, in this issue.
+
+**Is your feature request related to a problem in the current program to new available techology or software? Please describe and add links/citations if appropriate.**
+A clear and concise description of what the problem is or what the advance you would like us to incorporate is. Ex. when triaging structural variantS, I would like to [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/other-issue.md
+++ b/.github/ISSUE_TEMPLATE/other-issue.md
@@ -1,0 +1,13 @@
+---
+name: Other issue
+about: Describe your issue, request or question here
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+Try to be as clear and precise as possible, adding sufficient detail and context.
+
+**⚠️ Important:** Please avoid sharing any sensitive or personal information, including text or images, in this issue.
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Try to use the following format:
 ## [unreleased]
 ### Added
 - Pre-commit hooks with ruff for automatic check and format ([#200](https://github.com/Clinical-Genomics/genmod/pull/200))
-- Issue templates for bug reports and feature requests ([#211](https://github.com/Clinical-Genomics/genmod/pull/195))
+- Issue templates for bug reports and feature requests ([#211](https://github.com/Clinical-Genomics/genmod/pull/211))
 ### Changed
 - Compounds `print_variant()` to use `cat` which provides significant speedups for large variants ([#189](https://github.com/Clinical-Genomics/genmod/pull/189))
 - Return phased genotype string from Genotype class if variant is phased ([#195](https://github.com/Clinical-Genomics/genmod/pull/195))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Try to use the following format:
 ## [unreleased]
 ### Added
 - Pre-commit hooks with ruff for automatic check and format ([#200](https://github.com/Clinical-Genomics/genmod/pull/200))
+- Issue templates for bug reports and feature requests ([#211](https://github.com/Clinical-Genomics/genmod/pull/195))
 ### Changed
 - Compounds `print_variant()` to use `cat` which provides significant speedups for large variants ([#189](https://github.com/Clinical-Genomics/genmod/pull/189))
 - Return phased genotype string from Genotype class if variant is phased ([#195](https://github.com/Clinical-Genomics/genmod/pull/195))


### PR DESCRIPTION
## Description

As a developer, I would very much not like to see Management Religion texts on the repos. 😉 

This conforms to the standard for Scout and related tools. There is also a (nearly) blank Other issue that can be used should the user absolutely crave a formulation in User Story mapping / C3 / Agile-land. 
